### PR TITLE
Upgrade nix dependency to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-nix = "0.8"
+nix = { version = "0.29", features = ["net", "socket"] }
 libc = "0.2"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-use libc::{c_void, c_char, c_int, c_uint};
+use libc::{AF_INET, AF_INET6, c_void, c_char, c_int, c_uint};
 use std::{mem, ptr};
 use nix::sys::socket;
 
@@ -66,7 +66,7 @@ pub fn convert_sockaddr (sa: *mut socket::sockaddr) -> Option<SocketAddr> {
     if sa == ptr::null_mut() { return None; }
 
     match unsafe { *sa }.sa_family as i32 {
-        socket::AF_INET => {
+        AF_INET => {
             let sa: *const socket::sockaddr_in = unsafe { mem::transmute(sa) };
             let sa = & unsafe { *sa };
             let addr: [u8; 4] = unsafe { mem::transmute(sa.sin_addr.s_addr) };
@@ -79,7 +79,7 @@ pub fn convert_sockaddr (sa: *mut socket::sockaddr) -> Option<SocketAddr> {
                 ), sa.sin_port
             )))
         },
-        socket::AF_INET6 => {
+        AF_INET6 => {
             let sa: *const socket::sockaddr_in6 = unsafe { mem::transmute(sa) };
             let sa = & unsafe { *sa };
             let addr: [u16; 8] = unsafe { mem::transmute(sa.sin6_addr.s6_addr) };

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,4 +1,4 @@
-use libc;
+use libc::{self, AF_INET, AF_INET6};
 use std::ffi::CStr;
 use std::{mem, net, ptr};
 
@@ -75,8 +75,8 @@ fn convert_ifaddrs (ifa: *mut ffi::ifaddrs) -> Option<Interface> {
     let kind = if ifa.ifa_addr != ptr::null_mut() {
         match unsafe { *ifa.ifa_addr }.sa_family as i32 {
             ffi::AF_PACKET => Kind::Packet,
-            socket::AF_INET => Kind::Ipv4,
-            socket::AF_INET6 => Kind::Ipv6,
+            AF_INET => Kind::Ipv4,
+            AF_INET6 => Kind::Ipv6,
             _ => return None,
         }
     } else {


### PR DESCRIPTION
This resolves a future-incompatibility warning on the transitive `bitflags` dependency.